### PR TITLE
Remove dependency from aws-sdk-promise. r=jhford

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,4 +1,4 @@
-var aws = require('aws-sdk-promise');
+var aws = require('aws-sdk');
 var S3 = aws.S3;
 
 var express = require('express');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "ironmq-promise": "0.0.1",
     "uuid": "~1.4.1",
     "express": "~3.4.8",
-    "aws-sdk-promise": "0.0.0",
     "aws-sdk": "~2.0.0-rc9",
     "azure-sas": "0.0.1",
     "azure": "~0.8.1",


### PR DESCRIPTION
Amazon has added the .promise() function to aws-sdk and aws-sdk-promise
isn't required anymore. Furthermore, aws-sdk-promise is going to be
deprecated. Details: http://tinyurl.com/hry2fa3
